### PR TITLE
Add SF Symbols to NSMenuItems for Enhanced UI Consistency

### DIFF
--- a/apple/InlineMac/App/AppMenu.swift
+++ b/apple/InlineMac/App/AppMenu.swift
@@ -86,6 +86,7 @@ final class AppMenu: NSObject {
       keyEquivalent: ""
     )
     logoutMenuItem.target = self
+    logoutMenuItem.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right", accessibilityDescription: nil)
     appMenu.addItem(logoutMenuItem)
 
     let clearCacheMenuItem = NSMenuItem(
@@ -94,6 +95,7 @@ final class AppMenu: NSObject {
       keyEquivalent: ""
     )
     clearCacheMenuItem.target = self
+    clearCacheMenuItem.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
     appMenu.addItem(clearCacheMenuItem)
 
     let clearMediaCacheMenuItem = NSMenuItem(
@@ -349,6 +351,7 @@ final class AppMenu: NSObject {
     )
     toggleSidebarItem.keyEquivalentModifierMask = [.command]
     toggleSidebarItem.target = self
+    toggleSidebarItem.image = NSImage(systemSymbolName: "sidebar.left", accessibilityDescription: nil)
     viewMenu.addItem(toggleSidebarItem)
 
     viewMenu.addItem(NSMenuItem.separator())
@@ -409,6 +412,7 @@ final class AppMenu: NSObject {
     )
     alwaysOnTopItem.keyEquivalentModifierMask = [.command, .option]
     alwaysOnTopItem.target = self
+    alwaysOnTopItem.image = NSImage(systemSymbolName: "pin", accessibilityDescription: nil)
     windowMenu.addItem(alwaysOnTopItem)
 
     windowMenu.addItem(NSMenuItem.separator())

--- a/apple/InlineMac/Views/Compose/ImageAttachment.swift
+++ b/apple/InlineMac/Views/Compose/ImageAttachment.swift
@@ -73,8 +73,14 @@ class ImageAttachmentView: NSView, QLPreviewItem {
 
   private func setupContextMenu() {
     let menu = NSMenu()
-    menu.addItem(withTitle: "Remove", action: #selector(removeButtonClicked), keyEquivalent: "")
-    menu.addItem(withTitle: "Copy", action: #selector(copyImage), keyEquivalent: "")
+    
+    let removeItem = NSMenuItem(title: "Remove", action: #selector(removeButtonClicked), keyEquivalent: "")
+    removeItem.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
+    menu.addItem(removeItem)
+    
+    let copyItem = NSMenuItem(title: "Copy", action: #selector(copyImage), keyEquivalent: "")
+    copyItem.image = NSImage(systemSymbolName: "document.on.document", accessibilityDescription: nil)
+    menu.addItem(copyItem)
 
     self.menu = menu
   }

--- a/apple/InlineMac/Views/Home/SpaceMembersView.swift
+++ b/apple/InlineMac/Views/Home/SpaceMembersView.swift
@@ -151,11 +151,11 @@ struct SpaceMembersView: View {
   @ViewBuilder
   var plusButton: some View {
     Menu {
-      Button("New Chat") {
+      Button("New Chat", systemImage: "bubble.left") {
         nav.open(.newChat(spaceId: spaceId))
       }
 
-      Button("Invite to Space") {
+      Button("Invite to Space", systemImage: "person.badge.plus") {
         nav.open(.inviteToSpace(spaceId: spaceId))
       }
     } label: {

--- a/apple/InlineMac/Views/MainSidebar/SpaceSidebar.swift
+++ b/apple/InlineMac/Views/MainSidebar/SpaceSidebar.swift
@@ -246,12 +246,11 @@ struct SpaceSidebar: View {
   @ViewBuilder
   var plusButton: some View {
     Menu {
-      // Button("New Chat") {
-      Button("New Chat") {
+      Button("New Chat", systemImage: "bubble.left") {
         nav.open(.newChat(spaceId: spaceId))
       }
 
-      Button("Invite to Space") {
+      Button("Invite to Space", systemImage: "person.badge.plus") {
         nav.open(.inviteToSpace(spaceId: spaceId))
       }
     } label: {

--- a/apple/InlineMac/Views/Message/Attachments/ExternalTaskAttachmentView.swift
+++ b/apple/InlineMac/Views/Message/Attachments/ExternalTaskAttachmentView.swift
@@ -222,16 +222,19 @@ class ExternalTaskAttachmentView: NSView, AttachmentView {
 
     let openAction = NSMenuItem(title: "Open URL", action: #selector(openURL), keyEquivalent: "")
     openAction.target = self
+    openAction.image = NSImage(systemSymbolName: "arrow.up.right.square", accessibilityDescription: nil)
     menu.addItem(openAction)
 
     let copyAction = NSMenuItem(title: "Copy URL", action: #selector(copyURL), keyEquivalent: "")
     copyAction.target = self
+    copyAction.image = NSImage(systemSymbolName: "document.on.document", accessibilityDescription: nil)
     menu.addItem(copyAction)
 
     menu.addItem(NSMenuItem.separator())
 
     let deleteAction = NSMenuItem(title: "Delete", action: #selector(showDeleteConfirmation), keyEquivalent: "")
     deleteAction.target = self
+    deleteAction.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
     menu.addItem(deleteAction)
 
     NSMenu.popUpContextMenu(menu, with: NSApp.currentEvent!, for: self)

--- a/apple/InlineMac/Views/NewSidebar/SidebarItemRow.swift
+++ b/apple/InlineMac/Views/NewSidebar/SidebarItemRow.swift
@@ -473,6 +473,7 @@ class SidebarItemRow: NSTableCellView {
       keyEquivalent: "p"
     )
     pinItem.target = self
+    pinItem.image = NSImage(systemSymbolName: isPinned ? "pin.slash" : "pin", accessibilityDescription: nil)
     menu.addItem(pinItem)
 
     // Archive item
@@ -482,6 +483,7 @@ class SidebarItemRow: NSTableCellView {
       keyEquivalent: "a"
     )
     archiveItem.target = self
+    archiveItem.image = NSImage(systemSymbolName: isArchived ? "archivebox" : "archivebox", accessibilityDescription: nil)
     menu.addItem(archiveItem)
 
     if isThread {
@@ -495,6 +497,7 @@ class SidebarItemRow: NSTableCellView {
         keyEquivalent: ""
       )
       deleteItem.target = self
+      deleteItem.image = NSImage(systemSymbolName: "trash", accessibilityDescription: nil)
       deleteItem.attributedTitle = NSAttributedString(
         string: "Delete",
         attributes: [.foregroundColor: NSColor.systemRed]


### PR DESCRIPTION
## Summary
- Adds SF Symbols icons to various NSMenuItems across the macOS app
- Improves visual consistency and user experience in menus and context menus

## Changes

### AppMenu
- Added system symbol icons to logout, clear cache, toggle sidebar, and always on top menu items

### ImageAttachmentView
- Added trash and document icons to context menu items for Remove and Copy actions

### SpaceMembersView & SpaceSidebar
- Updated buttons in menus to use SF Symbols for "New Chat" and "Invite to Space"

### ExternalTaskAttachmentView
- Added icons for Open URL, Copy URL, and Delete actions in context menu

### SidebarItemRow
- Added icons for pin, archive, and delete menu items

## Test plan
- Verify icons appear correctly in all updated menus and context menus
- Test menu item functionality remains intact
- Confirm visual consistency across different parts of the app menus

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/13c728b0-ec4f-4165-884b-78b1c6bdaae7