### PR TITLE
Fix red bubble display for failed outgoing messages on iOS with theme support

### DIFF
--- a/apple/InlineIOS/Features/Message/UIMessageView.swift
+++ b/apple/InlineIOS/Features/Message/UIMessageView.swift
@@ -43,16 +43,25 @@ class UIMessageView: UIView {
 
   var bubbleColor: UIColor {
     if isEmojiOnlyMessage || isSticker || shouldShowFloatingMetadata {
-      UIColor.clear
+      return UIColor.clear
     } else if outgoing {
-      ThemeManager.shared.selected.bubbleBackground
+      // Show red bubble for failed messages to match iOS system styling
+      if message.status == .failed {
+        return UIColor.systemRed
+      } else {
+        return ThemeManager.shared.selected.bubbleBackground
+      }
     } else {
-      ThemeManager.shared.selected.incomingBubbleBackground
+      return ThemeManager.shared.selected.incomingBubbleBackground
     }
   }
 
   var textColor: UIColor {
-    outgoing ? .white : ThemeManager.shared.selected.primaryTextColor ?? .label
+    if outgoing {
+      .white
+    } else {
+      ThemeManager.shared.selected.primaryTextColor ?? .label
+    }
   }
 
   var message: Message {
@@ -253,6 +262,10 @@ class UIMessageView: UIView {
     shineEffectView?.stopAnimation()
     shineEffectView?.removeFromSuperview()
     shineEffectView = nil
+  }
+  
+  public func refreshAppearance() {
+    setupAppearance()
   }
 
   func reset() {

--- a/apple/InlineIOS/Features/Message/UIMessageView.swift
+++ b/apple/InlineIOS/Features/Message/UIMessageView.swift
@@ -45,9 +45,9 @@ class UIMessageView: UIView {
     if isEmojiOnlyMessage || isSticker || shouldShowFloatingMetadata {
       return UIColor.clear
     } else if outgoing {
-      // Show red bubble for failed messages to match iOS system styling
+      // Show red bubble for failed messages using theme-aware color
       if message.status == .failed {
-        return UIColor.systemRed
+        return ThemeManager.shared.selected.failedBubbleBackground
       } else {
         return ThemeManager.shared.selected.bubbleBackground
       }

--- a/apple/InlineIOS/UI/ThemeManager.swift
+++ b/apple/InlineIOS/UI/ThemeManager.swift
@@ -7,6 +7,7 @@ protocol ThemeConfig {
 
   var bubbleBackground: UIColor { get }
   var incomingBubbleBackground: UIColor { get }
+  var failedBubbleBackground: UIColor { get }
 
   // only for incoming messages for now
   var primaryTextColor: UIColor? { get }

--- a/apple/InlineIOS/UI/Themes.swift
+++ b/apple/InlineIOS/UI/Themes.swift
@@ -21,6 +21,8 @@ struct Default: ThemeConfig {
   })
 
   var accent: UIColor = .init(hex: "#52A5FF")!
+  
+  var failedBubbleBackground: UIColor = .systemRed
 
   var reactionOutgoingPrimary: UIColor? = .white
   var reactionOutgoingSecoundry: UIColor? = .white.withAlphaComponent(0.08)
@@ -111,6 +113,8 @@ struct CatppuccinMocha: ThemeConfig {
       UIColor(hex: "#7287FD")!
     }
   })
+  
+  var failedBubbleBackground: UIColor = UIColor(hex: "#f38ba8")!
 
   var reactionOutgoingPrimary: UIColor? = .white
   var reactionOutgoingSecoundry: UIColor? = .white.withAlphaComponent(0.08)
@@ -263,6 +267,9 @@ struct PeonyPink: ThemeConfig {
   })
 
   var accent: UIColor = .init(hex: "#FF82B8")!
+  
+  var failedBubbleBackground: UIColor = .systemRed
+  
   var reactionOutgoingPrimary: UIColor? = .white
   var reactionOutgoingSecoundry: UIColor? = .white.withAlphaComponent(0.08)
 
@@ -328,6 +335,8 @@ struct Orchid: ThemeConfig {
   })
 
   var accent: UIColor = .init(hex: "#a28cf2")!
+  
+  var failedBubbleBackground: UIColor = .systemRed
 
   var reactionOutgoingPrimary: UIColor? = .white
   var reactionOutgoingSecoundry: UIColor? = .white.withAlphaComponent(0.08)


### PR DESCRIPTION
## Summary
- Fixes the bubble color for failed outgoing messages to display a red bubble, matching iOS system styling
- Adds theme support for failed message bubble color via `failedBubbleBackground` in `ThemeConfig`
- Improves message bubble appearance logic in `UIMessageView` for better visual feedback on message status
- Adds a `refreshAppearance` method to allow refreshing the message view's appearance dynamically

## Changes

### UIMessageView.swift
- Updated `bubbleColor` computed property to return `ThemeManager.shared.selected.failedBubbleBackground` for messages with `.failed` status when outgoing
- Refactored color return statements for clarity and consistency
- Added `refreshAppearance()` method to call `setupAppearance()` for UI refresh

### ThemeManager.swift
- Added `failedBubbleBackground` property to `ThemeConfig` protocol

### Themes.swift
- Added `failedBubbleBackground` color to all theme structs with appropriate red colors

## Test plan
- [x] Verify that failed outgoing messages show a red bubble using the theme's `failedBubbleBackground` color
- [x] Confirm that other outgoing messages use the theme's bubble background color
- [x] Check incoming messages retain their bubble background color
- [x] Test that calling `refreshAppearance()` updates the UI correctly

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/92c02a13-d438-41b7-b40f-6d8baa1633a0