### PR TITLE
Fix chat header subtitle layout and prevent dancing effect

### DIFF
--- a/apple/InlineIOS/Features/Chat/ChatView+extensions.swift
+++ b/apple/InlineIOS/Features/Chat/ChatView+extensions.swift
@@ -104,18 +104,16 @@ extension ChatView {
   @ViewBuilder
   var subtitleView: some View {
     let subtitle = getCurrentSubtitle()
-    if !subtitle.text.isEmpty {
-      HStack(alignment: .center, spacing: 4) {
-        subtitle.animatedIndicator.padding(.top, 2)
+    HStack(alignment: .center, spacing: 4) {
+      subtitle.animatedIndicator.padding(.top, 2)
 
-        Text(subtitle.text.lowercased())
-          .font(.caption)
-//          .foregroundStyle(subtitle.isComposeAction ? Color(ThemeManager.shared.selected.accent) : .secondary)
-          .foregroundStyle(.secondary)
-      }
-      .padding(.top, -2)
-      .fixedSize()
+      Text(subtitle.text.isEmpty ? " " : subtitle.text.lowercased())
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .opacity(subtitle.text.isEmpty ? 0 : 1)
     }
+    .padding(.top, -2)
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 }
 

--- a/apple/InlineIOS/Features/Chat/ChatView.swift
+++ b/apple/InlineIOS/Features/Chat/ChatView.swift
@@ -181,10 +181,11 @@ struct ChatView: View {
         Text(title)
           .font(.body)
         subtitleView
+          .frame(minHeight: 16)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
     }
-    .scaledToFill()
-    .fixedSize()
+    .frame(maxWidth: .infinity, alignment: .leading)
     .onTapGesture {
       if let chatItem = fullChatViewModel.chatItem {
         router.push(.chatInfo(chatItem: chatItem))


### PR DESCRIPTION
## Summary
- Fixes the chat header subtitle view to prevent layout jumping or "dancing" effect
- Ensures subtitle text always occupies space even when empty, stabilizing header height
- Aligns subtitle and title views consistently to the leading edge

## Changes

### UI Adjustments
- Modified `subtitleView` in `ChatView+extensions.swift`:
  - Always render subtitle text with a space if empty to maintain layout
  - Use opacity to hide empty subtitle text instead of removing it
  - Added `.frame(maxWidth: .infinity, alignment: .leading)` to subtitle container
- Updated `ChatView.swift`:
  - Added `.frame(minHeight: 16)` to subtitleView to reserve vertical space
  - Aligned title and subtitle container to leading with `.frame(maxWidth: .infinity, alignment: .leading)`
  - Removed `.scaledToFill()` and `.fixedSize()` modifiers that affected layout

## Test plan
- [x] Verify chat header subtitle does not cause layout shifts when text changes
- [x] Confirm subtitle text is properly aligned and visible when present
- [x] Check that tapping chat header still triggers navigation as expected
- [x] Test on different device sizes to ensure consistent header appearance

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/59f56a76-7cbf-48e6-ab70-28d7e785d3bf