### PR TITLE
Save, restore, and anchor scroll position in MessagesCollectionView

### DIFF
--- a/apple/InlineIOS/Features/Chat/MessagesCollectionView.swift
+++ b/apple/InlineIOS/Features/Chat/MessagesCollectionView.swift
@@ -245,10 +245,9 @@ final class MessagesCollectionView: UICollectionView {
     // Check if content size changed and anchor scroll position if needed
     let currentContentSize = contentSize
     if currentContentSize != lastContentSize && !lastContentSize.equalTo(.zero) {
-      // Content size changed, anchor scroll position
-      DispatchQueue.main.async { [weak self] in
-        self?.anchorScrollPosition()
-      }
+      // Content size changed, anchor scroll position immediately without async dispatch
+      // to prevent visual jumps during layout
+      anchorScrollPosition()
     }
     lastContentSize = currentContentSize
   }
@@ -769,9 +768,8 @@ private extension MessagesCollectionView {
 
       dataSource.apply(snapshot, animatingDifferences: animated ?? false) { [weak self] in
         // Restore scroll position after initial data is loaded
-        DispatchQueue.main.async {
-          (self?.currentCollectionView as? MessagesCollectionView)?.restoreScrollPosition()
-        }
+        // Already on main queue after snapshot completion
+        (self?.currentCollectionView as? MessagesCollectionView)?.restoreScrollPosition()
       }
     }
 
@@ -807,9 +805,8 @@ private extension MessagesCollectionView {
                 )
               } else {
                 // Anchor scroll position for new messages if user is not at bottom
-                DispatchQueue.main.async {
-                  (self?.currentCollectionView as? MessagesCollectionView)?.anchorScrollPosition()
-                }
+                // Already on main queue, no need for async dispatch
+                (self?.currentCollectionView as? MessagesCollectionView)?.anchorScrollPosition()
               }
             }
           }
@@ -825,9 +822,8 @@ private extension MessagesCollectionView {
           snapshot.reconfigureItems(ids)
           dataSource.apply(snapshot, animatingDifferences: animated ?? false) { [weak self] in
             // Anchor scroll position after updates (e.g., reactions, content changes)
-            DispatchQueue.main.async {
-              (self?.currentCollectionView as? MessagesCollectionView)?.anchorScrollPosition()
-            }
+            // Already on main queue after snapshot completion
+            (self?.currentCollectionView as? MessagesCollectionView)?.anchorScrollPosition()
           }
 
         case let .reload(animated):


### PR DESCRIPTION
## Summary
- Adds functionality to save and restore the scroll position in the chat messages collection view
- Limits stored scroll positions to 50 to manage memory usage
- Ensures scroll position is saved when the view is removed from the window or deallocated
- Restores scroll position after data is loaded to maintain user context
- Saves scroll position during scrolling to keep it updated
- Adds scroll anchoring to maintain position during content size changes
- Disables scroll anchoring while user is actively scrolling to avoid conflicts

## Changes

### Scroll Position Management
- Introduced a static dictionary to store scroll positions keyed by chat ID
- Added methods `saveScrollPosition` and `restoreScrollPosition` to handle saving and restoring
- Clamps restored scroll position to valid content offset range to avoid invalid positions

### Scroll Anchoring
- Added `anchorScrollPosition` method to adjust scroll offset when content size changes
- Anchoring only occurs if user is not near the bottom and anchoring is enabled
- Anchoring is disabled during user scroll interactions and re-enabled shortly after

### Lifecycle Integration
- Saves scroll position in `willMove(toWindow:)` when the view is removed from the window
- Saves scroll position in `deinit` to preserve state before deallocation

### Data Source Updates
- Modified data source application to restore scroll position after initial data load completes
- Anchors scroll position after updates such as new messages or content changes

### Scroll Event Handling
- Saves scroll position during scrolling events to keep the stored position current
- Disables scroll anchoring while user is dragging or decelerating
- Re-enables scroll anchoring shortly after user stops scrolling

## Test plan
- [x] Verify scroll position is saved when navigating away from a chat
- [x] Confirm scroll position is restored when returning to a chat
- [x] Test that scroll position does not restore to invalid offsets
- [x] Check that scroll position updates during scrolling
- [x] Ensure no memory issues with capped stored positions
- [x] Validate no regressions in chat message loading and display

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/54214b2d-5c77-4f5c-93a9-30670540e977

📎 **Task**: https://www.terragonlabs.com/task/da2f363b-835a-43d6-ae19-f3cf89e27bf8