### PR TITLE
Fix checkmark color for outgoing reactions by non-current users

### DIFF
--- a/apple/InlineIOS/Features/Reactions/MessageReactionView.swift
+++ b/apple/InlineIOS/Features/Reactions/MessageReactionView.swift
@@ -95,7 +95,7 @@ class MessageReactionView: UIView, UIContextMenuInteractionDelegate, UIGestureRe
   private func configureEmojiLabel(_ label: UILabel) {
     if emoji == "✓" || emoji == "✔️" {
       let config = UIImage.SymbolConfiguration(pointSize: Constants.emojiSize, weight: .semibold)
-      let checkmarkColor = byCurrentUser && !outgoing ? UIColor.white : UIColor(hex: "#2AAC28")!
+      let checkmarkColor = (byCurrentUser && !outgoing) || (!byCurrentUser && outgoing) ? UIColor.white : UIColor(hex: "#2AAC28")!
       let checkmarkImage = UIImage(systemName: "checkmark", withConfiguration: config)?
         .withTintColor(checkmarkColor, renderingMode: .alwaysOriginal)
 


### PR DESCRIPTION
## Summary
- Corrects the checkmark color display logic in message reactions
- Ensures outgoing reactions by non-current users show the checkmark in white

## Changes

### MessageReactionView
- Updated condition for `checkmarkColor` to:
  - Use white color if the reaction is by the current user and not outgoing
  - Or if the reaction is by a non-current user and outgoing
  - Otherwise, use the green color (#2AAC28)

## Test plan
- Verify checkmark color is white for outgoing reactions by non-current users
- Verify checkmark color remains white for reactions by current user that are not outgoing
- Verify checkmark color is green for other cases
- Test with both checkmark emojis (`✓` and `✔️`) to confirm consistent behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d8017c83-60d7-4db4-ba95-444315d5ae03